### PR TITLE
fix return value for incoming-message webhook

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -108,7 +108,13 @@ export class Twilio<
           },
         );
 
-        return new Response(null, { status: 200 });
+        const emptyResponseTwiML = `
+<?xml version="1.0" encoding="UTF-8"?>
+<Response></Response>`;
+
+        return new Response(emptyResponseTwiML, { status: 200, headers: {
+          'Content-Type': 'application/xml',
+        } });
       }),
     });
   }


### PR DESCRIPTION
<!-- Describe your PR here. -->

we're getting twilio errors `11200 - HTTP retrieval failure` because we're sending empty responses instead of the xml that twilio is expecting

https://www.twilio.com/docs/usage/webhooks/messaging-webhooks#incoming-message-webhook

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
