### PR TITLE
Include voice_receive_mode in phone_numbers schema

### DIFF
--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -78,6 +78,7 @@ export default defineSchema({
     voice_fallback_url: v.string(),
     voice_method: v.string(),
     voice_url: v.string(),
+    voice_receive_mode: v.optional(v.string()),
   })
     .index("by_phone_number", ["account_sid", "phone_number"])
     .index("by_sid", ["account_sid", "sid"]),


### PR DESCRIPTION
As seen in the [twilio docs](https://www.twilio.com/docs/phone-numbers/api/incomingphonenumber-resource), phone numbers may (in my case always) include a `voice_receive_mode` property.  Without this update I am receiving the following error.

```
11/24/2025, 12:30:41 PM [CONVEX A(phone_numbers:updateSmsUrl)] Uncaught Error: Uncaught Error: Failed to insert or update a document in table "phone_numbers" because it does not match the schema: Object contains extra field `voice_receive_mode` that is not in the validator.
```


----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
